### PR TITLE
Fix staff-list router import

### DIFF
--- a/components/staff-list.tsx
+++ b/components/staff-list.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -5,7 +6,7 @@ import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { DatePicker } from "@/components/ui/date-picker"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 interface StaffListProps {
   onDriverSelect: (driverId: string) => void


### PR DESCRIPTION
## Summary
- mark `components/staff-list.tsx` as a client component
- switch router import to `next/navigation`

## Testing
- `npm run build` *(fails: Can't resolve `@/components/staff-detail-routes` etc.)*
- `pnpm build` *(fails: Can't resolve `@/components/staff-detail-routes` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6874e8f80d18833385c953546c3652dc