### PR TITLE
Fix duplicate toast listeners

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure `useToast` registers the listener only once

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: Next.js eslint setup prompt)*
- `npm run build` *(fails: missing modules & syntax errors)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6874eb70ce5083338ededc27b96db92f