### PR TITLE
Add autoprefixer to PostCSS plugins

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -2,6 +2,7 @@
 const config = {
   plugins: {
     tailwindcss: {},
+    autoprefixer: {},
   },
 };
 


### PR DESCRIPTION
## Summary
- enable autoprefixer in PostCSS configuration

## Testing
- `npm install`
- `npx tailwindcss -i styles/globals.css -o /tmp/output.css --postcss`

------
https://chatgpt.com/codex/tasks/task_e_687584d2d1d483339a6e50943d1b2d84